### PR TITLE
fix: zk security audit fixes

### DIFF
--- a/solidity/contracts/main/tokenservice/TokenServiceV3.sol
+++ b/solidity/contracts/main/tokenservice/TokenServiceV3.sol
@@ -267,14 +267,23 @@ contract TokenServiceV3 is TokenServiceV2 {
     ) external virtual nonReentrant whenNotPaused {
         require(
             packet.destTokenService.addr == address(this),
-            "TokenService: invalidToken"
+            "TokenService: invalidDestTokenService"
         );
+
+        require(destChainId == packet.sourceTokenService.chainId, "TokenService: invalidSourceChainId");
+        require(self.chainId == packet.destTokenService.chainId, "TokenService: invalidDestChainId");
 
         address receiver = packet.message.receiverAddress;
         address tokenAddress = packet.message.destTokenAddress;
-        require(isEnabledToken(tokenAddress), "TokenService: invalidToken");
-        
         uint256 amount = packet.message.amount;
+
+        require(isEnabledToken(tokenAddress), "TokenService: invalidToken");
+        require(amount > 0, "TokenService: invalidAmount");
+         require(
+            keccak256(abi.encodePacked(packet.sourceTokenService.addr)) == 
+            keccak256(abi.encodePacked(supportedTokens[tokenAddress].destTokenService)),
+            "TokenService: invalidSourceTokenService"
+        );  
 
         PacketLibrary.Vote quorum = erc20Bridge.consume(packet, signatures);
 


### PR DESCRIPTION
This pull request strengthens the validation logic of the `TokenServiceV3` contract's `withdraw` function and adds comprehensive test coverage to ensure these new checks work as intended. The changes improve security by enforcing stricter checks on packet fields and enhance test reliability by verifying all failure and success scenarios.

**Smart contract validation improvements:**

* Added new validation checks in `TokenServiceV3.withdraw` to ensure:
  - The destination token service address matches the contract (`invalidDestTokenService`).
  - The source and destination chain IDs are correct (`invalidSourceChainId`, `invalidDestChainId`).
  - The token is enabled (`invalidToken`), the withdrawal amount is greater than zero (`invalidAmount`), and the source token service matches the expected value (`invalidSourceTokenService`).

**Test suite enhancements:**

* Introduced a new test suite in `011.TokenServiceV3.test.js` that covers all new validation checks in the `withdraw` function, including cases for wrong destination address, chain IDs, unsupported tokens, zero amount, mismatched source token service, and a valid withdrawal scenario.