### PR TITLE
fix: hash signing logic and update tests

### DIFF
--- a/attestor/signingService/chain/ethereum/hash.go
+++ b/attestor/signingService/chain/ethereum/hash.go
@@ -55,15 +55,9 @@ func hash(sp *chainService.ScreenedPacket) string {
 		ethCommon.HexToAddress(sp.Packet.Message.ReceiverAddress).Bytes(),
 		heightBytes,
 	)
-
-	fmt.Println("hello", pktHash.String())
-
 	hashOfPktHashAndVote := crypto.Keccak256Hash(pktHash.Bytes(), getEthBoolByte(sp.IsWhite))
-
-	fmt.Println(hashOfPktHashAndVote.String())
-
-	// finalHash := crypto.Keccak256Hash([]byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(hashOfPktHashAndVote))), hashOfPktHashAndVote.Bytes())
-	return hashOfPktHashAndVote.Hex()
+	finalHash := crypto.Keccak256Hash([]byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(hashOfPktHashAndVote))), hashOfPktHashAndVote.Bytes())
+	return finalHash.Hex()
 }
 
 func getEthBoolByte(b bool) []byte {

--- a/attestor/signingService/chain/ethereum/hash_test.go
+++ b/attestor/signingService/chain/ethereum/hash_test.go
@@ -11,29 +11,29 @@ import (
 func TestHash(t *testing.T) {
 	packet := chainService.Packet{
 		Version:  uint8(1),
-		Sequence: uint64(1),
+		Sequence: uint64(16),
 		Source: chainService.NetworkAddress{
-			ChainID: big.NewInt(2),
-			Address: "aleo1fg8y0ax9g0yhahrknngzwxkpcf7ejy3mm6cent4mmtwew5ueps8s6jzl27",
+			ChainID: big.NewInt(6694886634403),
+			Address: "aleo1ekhz75ffmguxcux7czmkry0ycrl4uwugcqc0qagn2y2qhm33lcpq74kmww",
 		},
 		Destination: chainService.NetworkAddress{
-			ChainID: big.NewInt(1),
-			Address: "0x2D9B1dF35e4fAc995377aD7f7a84070CD36400Ff",
+			ChainID: big.NewInt(422842677857),
+			Address: "0x29E9C4a930A8360364116aC931D0606A8f634524",
 		},
 		Message: chainService.Message{
-			SenderAddress:    "aleo1fg8y0ax9g0yhahrknngzwxkpcf7ejy3mm6cent4mmtwew5ueps8s6jzl27",
-			DestTokenAddress: "0xc9788ef51c8deB28F3F205b0B2F124F6884541A4",
-			Amount:           big.NewInt(10),
-			ReceiverAddress:  "0xBd31ba048373A07bE0357B7Ad3182F4206c8064d",
+			SenderAddress:    "aleo1ekhz75ffmguxcux7czmkry0ycrl4uwugcqc0qagn2y2qhm33lcpq74kmww",
+			DestTokenAddress: "0x0c1F973927B2D1403727977E8b3Da8A42d640AC0",
+			Amount:           big.NewInt(18000000),
+			ReceiverAddress:  "0x0C9119f08cF3361c3F3abbBC593a1CE2e63068f7",
 		},
-		Height: uint64(100),
+		Height: uint64(9987503),
 	}
 	t.Run("happy path", func(t *testing.T) {
 		h := hash(&chainService.ScreenedPacket{Packet: &packet, IsWhite: true})
-		assert.Equal(t, "0x01e80e351de9084e68e456b2f9fa18219ffc886f4bfc9e9ad629e5849263bb17", h)
+		assert.Equal(t, "0x5fed48e10cfa0f4922d33b2e9addfa84155ea79ad1ed84ea97280fdb941da6f4", h)
 	})
 	t.Run("different hash", func(t *testing.T) {
 		h := hash(&chainService.ScreenedPacket{Packet: &packet, IsWhite: false})
-		assert.Equal(t, "0xb08590719ae82971617235938e3044f11a8b6d652086ed0aacd9a79b900d5f33", h)
+		assert.Equal(t, "0x309007e3505b01cf3b58996f75091ec4ef7d3316d6218b687a8578a9d9aef126", h)
 	})
 }

--- a/attestor/signingService/chain/ethereum/sign.go
+++ b/attestor/signingService/chain/ethereum/sign.go
@@ -15,13 +15,12 @@ var pkeyMap = make(map[string]*ecdsa.PrivateKey)
 // sign returns the ecdsa signature of the attestors on the input hash string
 func sign(hashString string, chainName string) (string, error) {
 	hash := common.HexToHash(hashString)
-
 	ppKey := pkeyMap[chainName]
 	b, err := crypto.Sign(hash.Bytes(), ppKey)
 	if err != nil {
 		return "", err
 	}
-
+	b[64] += 27
 	return "0x" + common.Bytes2Hex(b), nil
 }
 

--- a/attestor/signingService/chain/ethereum/sign_test.go
+++ b/attestor/signingService/chain/ethereum/sign_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestValidateKeys(t *testing.T) {
-
 	t.Run("valid key should return nil error", func(t *testing.T) {
 		t.Cleanup(func() {
 			pkeyMap = nil
@@ -77,5 +76,20 @@ func TestSetUpPrivateKey(t *testing.T) {
 		require.Error(t, err)
 
 		require.Nil(t, pkeyMap["ethereum"])
+	})
+}
+
+func TestSignHash(t *testing.T) {
+	t.Run("sign hash", func(t *testing.T) {
+		keyDetails := config.KeyPair{
+			PrivateKey:    "b570a51f150a0cfb7a39017365e3cdc8da76af1805a5903f4b83e88eabdc9c21",
+			WalletAddress: "0x832894550007b560bd35d28ce564c2ccd690318f",
+			ChainType:     "evm",
+		}
+		err := SetUpPrivateKey(&keyDetails, "ethereum")
+		require.NoError(t, err)
+		sig, err := sign("0x5fed48e10cfa0f4922d33b2e9addfa84155ea79ad1ed84ea97280fdb941da6f4", "ethereum")
+		require.NoError(t, err)
+		require.Equal(t, "0xcf6708575951fce45d5fab038b65d2adc6ef1f27181e839d72200be13815623d229a5aa6e21003bbccce747bfaee33ff602236f2c15a6a1720f053c958e6e69b1c", sig)
 	})
 }


### PR DESCRIPTION
Refactor the hash function to correctly compute the final hash and update the signing function to adjust the signature format. Modify tests to reflect changes in expected hash values and add a new test for signing a hash.